### PR TITLE
Add new paper on egocentric procedural AI assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ This repository tracks egocentric video datasets through a task-first view: ever
 
 Sorted newest to oldest, with flagship surveys and corpus papers highlighted first.
 
+- **Building Egocentric Procedural AI Assistant: Methods, Benchmarks, and Challenges** (2025) — Li et al., 2025 survey and benchmark paper of egocentric procedural activity understanding, focus on building egocentric procedural AI assistant.
+  [![arXiv](https://img.shields.io/badge/arXiv-2511.13261-b31b1b.svg)](https://arxiv.org/abs/2511.13261)
+
 - [⭐️] **Challenges and Trends in Egocentric Vision: A Survey** (2025) — Li et al., 2025 survey of datasets, tasks, benchmarks, and open challenges in egocentric vision.
   [![arXiv](https://img.shields.io/badge/arXiv-2503.15275-b31b1b.svg)](https://arxiv.org/abs/2503.15275)
 


### PR DESCRIPTION
Added a new survey paper on building egocentric procedural AI assistants, including a link to the arXiv.

## Summary

Survey and benchmark paper of egocentric procedural activity understanding, focusing on building egocentric procedural AI assistant.

## Type Of Change

- [ ] Add a new dataset
- [ ] Update an existing dataset entry
- [ ] Add or update a benchmark/challenge entry in `benchmarks.md`
- [ ] Add or update a tool/resource entry in `README.md`
- [ ] Fix formatting / consistency / broken links

## Files Updated

- [x] `README.md`
- [ ] `benchmarks.md`
- [ ] `datasets.md` summary table
- [ ] `datasets.md` detailed entry
- [ ] One or more files under `tasks/`
- [ ] `CONTRIBUTING.md` or repository maintenance docs

## Contributor Checklist

- [x] I used official links when possible.
- [ ] Dataset name, year, and main link are consistent across all touched files.
- [ ] If I changed `datasets.md`, I updated both the summary table and the detailed entry when needed.
- [ ] I only added the dataset to task files where it is clearly relevant.
- [ ] If the PR adds or changes a benchmark, I updated `benchmarks.md` (correct year section, sort order).
- [ ] If a resource is not ego-only or is ego+exo, I labeled that clearly where appropriate.
- [ ] Markdown tables still render correctly after my edits.

## Notes

Add any context reviewers should know, such as year-convention decisions, archived links, or scope caveats.
